### PR TITLE
allocate memory as needed and free allocated memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ all: dtbTool-exynos
 
 dtbTool-exynos: $(OBJ_FILES)
 	$(CC) $(CFLAGS) -o $@ $^ -lfdt
-	strip $@
 
 clean:
 	rm -f dtbTool-exynos $(OBJ_FILES)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-OBJ_FILES := dtbtool-exynos.o /usr/lib/libfdt.so
+OBJ_FILES := dtbtool-exynos.o
 CFLAGS := -O2 -fomit-frame-pointer -Wall
 
 all: dtbTool-exynos
 
 dtbTool-exynos: $(OBJ_FILES)
-	$(CC) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^ -lfdt
 	strip $@
 
 clean:
-	rm -f $(OBJ_FILES)
+	rm -f dtbTool-exynos $(OBJ_FILES)

--- a/dtbtool-exynos.c
+++ b/dtbtool-exynos.c
@@ -188,16 +188,17 @@ void add_dtb_file(char ***dtb_files_ptr, int *dtb_count_ptr, const char *filenam
 }
 
 static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
-				 uint32_t platform_code, uint32_t subtype_code,
-				 unsigned *_sz)
+			     uint32_t platform_code, uint32_t subtype_code,
+			     unsigned *_sz)
 {
 	const unsigned pagemask = pagesize - 1;
-	struct dt_entry *new_entries;
+	struct dt_entry *new_entries = NULL;
 	struct dt_entry *entries = NULL;
 	struct dt_entry *entry;
-	struct dt_blob *blob;
+	struct dt_blob *blob = NULL;
 	struct dt_blob *blob_list = NULL;
 	struct dt_blob *last_blob = NULL;
+	struct dt_blob *tmp_blob = NULL;
 	unsigned new_count;
 	unsigned entry_count = 0;
 	unsigned offset;
@@ -210,15 +211,19 @@ static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
 	const unsigned *prop_hw_rev_end;
 	const unsigned *prop_compatible;
 	int len;
-	void *dtb;
-	char *dtbh;
+	void *dtb = NULL;
+	char *dtbh = NULL;
 	char **fname;
 	unsigned c;
+	bool fail = false;
 
 	for (fname = dtb_files; *fname; fname++) {
 		dtb = load_file(*fname, &dtb_sz);
-		if (!dtb || !dtb_sz)
+		if (!dtb || !dtb_sz) {
 			error("failed to read dtb '%s'", *fname);
+			fail = true;
+			goto cleanup;
+		}
 
 		if (fdt_check_header(dtb) != 0) {
 			warnx("'%s' is not a valid dtb, skipping", *fname);
@@ -262,8 +267,12 @@ static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
 				ntohl(prop_hw_rev[0]), ntohl(prop_hw_rev_end[0]));
 
 		blob = calloc(1, sizeof(struct dt_blob));
-		if (!blob)
+		if (!blob) {
 			error("failed to allocate memory");
+			free(dtb);
+			fail = true;
+			goto cleanup;
+		}
 
 		blob->payload = dtb;
 		blob->size = dtb_sz;
@@ -278,8 +287,11 @@ static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
 		blob_sz += (blob->size + pagemask) & ~pagemask;
 		new_count = entry_count + 1;
 		new_entries = realloc(entries, new_count * sizeof(struct dt_entry));
-		if (!new_entries)
+		if (!new_entries) {
 			error("failed to allocate memory");
+			fail = true;
+			goto cleanup;
+		}
 
 		entries = new_entries;
 		entry = &entries[entry_count];
@@ -299,7 +311,8 @@ static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
 
 	if (!entry_count) {
 		warnx("unable to locate any dtbs in the given path");
-		return 0;
+		fail = true;
+		goto cleanup;
 	}
 
 	hdr_sz += sizeof(uint32_t); /* eot marker */
@@ -324,8 +337,11 @@ static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
 	 * All parts are now gathered, so build the dt block
 	 */
 	dtbh = calloc(hdr_sz + blob_sz, 1);
-	if (!dtbh)
-		fail("failed to allocate memory");
+	if (!dtbh) {
+		error("failed to allocate memory");
+		fail = true;
+		goto cleanup;
+	}
 
 	offset = 0;
 
@@ -352,7 +368,20 @@ static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
 
 	*_sz = hdr_sz + blob_sz;
 
-	return dtbh;
+cleanup:
+	if (entries)
+		free(entries);
+	tmp_blob = blob_list;
+	while (tmp_blob) {
+		struct dt_blob *next = tmp_blob->next;
+		free(tmp_blob->payload);
+		free(tmp_blob);
+		tmp_blob = next;
+	}
+	if (fail)
+		return NULL;
+	else
+		return dtbh;
 }
 
 void free_dtb_files(char **dtb_files) {
@@ -447,10 +476,12 @@ int main(int argc, char **argv)
 	if (write(fd, dt_data, dt_size) != dt_size) {
 		unlink(dt_img);
 		close(fd);
+		free(dt_data);
 		free_dtb_files(dtb_files);
 		fail("failed writing '%s': %s", dt_img, strerror(errno));
 	}
 
+	free(dt_data);
 	free_dtb_files(dtb_files);
 	close(fd);
 

--- a/dtbtool-exynos.c
+++ b/dtbtool-exynos.c
@@ -129,16 +129,16 @@ static void *scan_dtb_path(char **dtb_files, const char *dtb_path)
 	if (files < 0)
 		error("failed to open '%s': %s", dtb_path, strerror(errno));
 
-    
-    printf("%s","List of files:\n############################################");
+
+	printf("%s","List of files:\n############################################");
 	for (f = 0, i = 0; f < files; f++) {
-        printf("%s",de[f]->d_name);
-        
+		printf("%s",de[f]->d_name);
+
 		namlen = strlen(de[f]->d_name);
 		if (namlen < 4 || strcmp(&de[f]->d_name[namlen - 4], ".dtb")) {
-            printf("%s"," : skipped");
+			printf("%s"," : skipped");
 			goto next_f;
-        }
+		}
 
 		/* skip over already allocated file names */
 		for (; dtb_files[i]; i++)
@@ -153,7 +153,7 @@ static void *scan_dtb_path(char **dtb_files, const char *dtb_path)
 		snprintf(dtb_files[i], namlen, "%s/%s", dtb_path, de[f]->d_name);
 next_f:
 		free(de[f]);
-        printf("%s\n","");
+		printf("%s\n","");
 	}
 	printf("%s\n","End list of files\n#######################################");
 
@@ -385,16 +385,16 @@ int main(int argc, char **argv)
 			read_val;
 			dt_subtype_code = strtoul(val, 0, 16);
 		} else if (*arg != '-') {
-		    /* skip over already allocated file names */
-            for (; dtb_files[dt_count]; dt_count++) {
-            	if (dt_count >= DTB_MAX) {
-            		fail("reached dtb file limit (%d)", DTB_MAX);
-            	}
-            }
-            dtb_files[dt_count] = strdup(arg);
-            if (!dtb_files[dt_count]) {
-            	fail("failed to allocate memory");
-            }
+			/* skip over already allocated file names */
+			for (; dtb_files[dt_count]; dt_count++) {
+				if (dt_count >= DTB_MAX) {
+					fail("reached dtb file limit (%d)", DTB_MAX);
+				}
+			}
+			dtb_files[dt_count] = strdup(arg);
+			if (!dtb_files[dt_count]) {
+				fail("failed to allocate memory");
+			}
 		} else
 			usage();
 	}

--- a/dtbtool-exynos.c
+++ b/dtbtool-exynos.c
@@ -429,14 +429,14 @@ int main(int argc, char **argv)
 	if (fd < 0)
 		fail("could not create output file '%s': %s", dt_img, strerror(errno));
 
-	if (write(fd, dt_data, dt_size) != dt_size) goto fail;
+	if (write(fd, dt_data, dt_size) != dt_size) {
+		unlink(dt_img);
+		close(fd);
+		fail("failed writing '%s': %s", dt_img, strerror(errno));
+	}
 
 	close(fd);
 
 	return 0;
 
-fail:
-	unlink(dt_img);
-	close(fd);
-	fail("failed writing '%s': %s", dt_img, strerror(errno));
 }

--- a/dtbtool-exynos.c
+++ b/dtbtool-exynos.c
@@ -129,14 +129,13 @@ static void *scan_dtb_path(char **dtb_files, const char *dtb_path)
 	if (files < 0)
 		error("failed to open '%s': %s", dtb_path, strerror(errno));
 
-
-	printf("%s","List of files:\n############################################");
+	printf("Scanning directory %s...\n", dtb_path);
 	for (f = 0, i = 0; f < files; f++) {
-		printf("%s",de[f]->d_name);
+		printf("%s", de[f]->d_name);
 
 		namlen = strlen(de[f]->d_name);
 		if (namlen < 4 || strcmp(&de[f]->d_name[namlen - 4], ".dtb")) {
-			printf("%s"," : skipped");
+			printf("%s", " : skipped");
 			goto next_f;
 		}
 
@@ -153,9 +152,8 @@ static void *scan_dtb_path(char **dtb_files, const char *dtb_path)
 		snprintf(dtb_files[i], namlen, "%s/%s", dtb_path, de[f]->d_name);
 next_f:
 		free(de[f]);
-		printf("%s\n","");
+		printf("%s\n", "");
 	}
-	printf("%s\n","End list of files\n#######################################");
 
 	return 0;
 }

--- a/dtbtool-exynos.c
+++ b/dtbtool-exynos.c
@@ -357,6 +357,8 @@ int main(int argc, char **argv)
 	dtb_files = malloc(sizeof(char*) * DTB_MAX);
 	if (!dtb_files)
 		error("failed to allocate memory");
+	else
+		memset(dtb_files, 0, sizeof(char*) * DTB_MAX);
 
 	while (argc > 0) {
 		argc--;

--- a/dtbtool-exynos.c
+++ b/dtbtool-exynos.c
@@ -154,6 +154,7 @@ next_f:
 		free(de[f]);
 		printf("%s\n", "");
 	}
+	free(de);
 
 	return 0;
 }

--- a/dtbtool-exynos.c
+++ b/dtbtool-exynos.c
@@ -355,6 +355,14 @@ static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
 	return dtbh;
 }
 
+void free_dtb_files(char **dtb_files) {
+	if (!dtb_files) return;
+	for (int i = 0; dtb_files[i]; i++) {
+		free(dtb_files[i]);
+	}
+	free(dtb_files);
+}
+
 static int usage(void)
 {
 	fprintf(stderr, "usage: dtbtool\n"
@@ -415,28 +423,36 @@ int main(int argc, char **argv)
 
 	if (!dt_img) {
 		error("no output filename specified");
+		free_dtb_files(dtb_files);
 		usage();
 	}
 
-	if (dt_count == 0)
+	if (dt_count == 0) {
+		free_dtb_files(dtb_files);
 		fail("no dtb files found");
+	}
 
 	dt_data = load_dtbh_block(dtb_files, pagesize, dt_platform_code, dt_subtype_code, &dt_size);
-	if (!dt_data)
+	if (!dt_data) {
+		free_dtb_files(dtb_files);
 		fail("could not load device tree blobs");
+	}
 
 	fd = open(dt_img, O_CREAT | O_TRUNC | O_WRONLY, 0644);
-	if (fd < 0)
+	if (fd < 0) {
+		free_dtb_files(dtb_files);
 		fail("could not create output file '%s': %s", dt_img, strerror(errno));
+	}
 
 	if (write(fd, dt_data, dt_size) != dt_size) {
 		unlink(dt_img);
 		close(fd);
+		free_dtb_files(dtb_files);
 		fail("failed writing '%s': %s", dt_img, strerror(errno));
 	}
 
+	free_dtb_files(dtb_files);
 	close(fd);
 
 	return 0;
-
 }

--- a/dtbtool-exynos.c
+++ b/dtbtool-exynos.c
@@ -119,18 +119,20 @@ oops:
 	return 0;
 }
 
-static void *scan_dtb_path(char **dtb_files, const char *dtb_path)
+static void scan_dtb_path(char ***dtb_files_ptr, int *dtb_count_ptr, const char *dtb_path)
 {
 	struct dirent **de;
-	int i, f, files, namlen;
+	int f, files, namlen;
 	const int dlen = strlen(dtb_path);
+	char **dtb_files = *dtb_files_ptr;
+	int dtb_count = *dtb_count_ptr;
 
 	files = scandir(dtb_path, &de, NULL, alphasort);
 	if (files < 0)
 		error("failed to open '%s': %s", dtb_path, strerror(errno));
 
 	printf("Scanning directory %s...\n", dtb_path);
-	for (f = 0, i = 0; f < files; f++) {
+	for (f = 0; f < files; f++) {
 		printf("%s", de[f]->d_name);
 
 		namlen = strlen(de[f]->d_name);
@@ -139,29 +141,55 @@ static void *scan_dtb_path(char **dtb_files, const char *dtb_path)
 			goto next_f;
 		}
 
-		/* skip over already allocated file names */
-		for (; dtb_files[i]; i++)
-			if (i >= DTB_MAX)
-				fail("reached dtb file limit (%d)", DTB_MAX);
+		char **new_files = realloc(dtb_files, sizeof(char*) * (dtb_count + 2));
+		if (!new_files)
+			fail("failed to allocate memory");
+		dtb_files = new_files;
 
 		namlen += dlen + 2; /* / and NULL terminator */
-		dtb_files[i] = calloc(namlen, sizeof(char));
-		if (!dtb_files[i])
+		dtb_files[dtb_count] = calloc(namlen, sizeof(char));
+		if (!dtb_files[dtb_count])
 			fail("failed to allocate memory");
 
-		snprintf(dtb_files[i], namlen, "%s/%s", dtb_path, de[f]->d_name);
+		snprintf(dtb_files[dtb_count], namlen, "%s/%s", dtb_path, de[f]->d_name);
+		dtb_count++;
+		dtb_files[dtb_count] = NULL;
+
 next_f:
 		free(de[f]);
 		printf("%s\n", "");
 	}
 	free(de);
 
-	return 0;
+	*dtb_files_ptr = dtb_files;
+	*dtb_count_ptr = dtb_count;
+}
+
+void add_dtb_file(char ***dtb_files_ptr, int *dtb_count_ptr, const char *filename) {
+	char **dtb_files = *dtb_files_ptr;
+	int dtb_count = *dtb_count_ptr;
+
+	if (dtb_count >= DTB_MAX) {
+		fail("reached dtb file limit (%d)", DTB_MAX);
+	}
+	char **new_files = realloc(dtb_files, sizeof(char*) * (dtb_count + 2));
+	if (!new_files)
+		fail("failed to allocate memory");
+	dtb_files = new_files;
+
+	dtb_files[dtb_count] = strdup(filename);
+	if (!dtb_files[dtb_count])
+		fail("failed to allocate memory");
+	dtb_count++;
+	dtb_files[dtb_count] = NULL;
+
+	*dtb_files_ptr = dtb_files;
+	*dtb_count_ptr = dtb_count;
 }
 
 static void *load_dtbh_block(char **dtb_files, unsigned pagesize,
-			     uint32_t platform_code, uint32_t subtype_code,
-			     unsigned *_sz)
+				 uint32_t platform_code, uint32_t subtype_code,
+				 unsigned *_sz)
 {
 	const unsigned pagemask = pagesize - 1;
 	struct dt_entry *new_entries;
@@ -347,18 +375,12 @@ int main(int argc, char **argv)
 	char *arg, *val;
 	char *dt_img = 0;
 	void *dt_data = 0;
-	char **dtb_files = 0;
+	char **dtb_files = NULL;
 	int fd, dt_count = 0;
 	unsigned pagesize = DTBH_PAGE_SIZE_DEF;
 	uint32_t dt_platform_code = DTBH_PLATFORM_CODE_DEF;
 	uint32_t dt_subtype_code = DTBH_SUBTYPE_CODE_DEF;
 	unsigned dt_size;
-
-	dtb_files = malloc(sizeof(char*) * DTB_MAX);
-	if (!dtb_files)
-		error("failed to allocate memory");
-	else
-		memset(dtb_files, 0, sizeof(char*) * DTB_MAX);
 
 	while (argc > 0) {
 		argc--;
@@ -375,7 +397,7 @@ int main(int argc, char **argv)
 				fail("unsupported page size %d\n", pagesize);
 		} else if (!strcmp(arg, "--dtb") || !strcmp(arg, "-d")) {
 			read_val;
-			scan_dtb_path(dtb_files, val);
+			scan_dtb_path(&dtb_files, &dt_count, val);
 		} else if (!strcmp(arg, "--output") || !strcmp(arg, "-o")) {
 			read_val;
 			dt_img = val;
@@ -385,17 +407,8 @@ int main(int argc, char **argv)
 		} else if (!strcmp(arg, "--subtype")) {
 			read_val;
 			dt_subtype_code = strtoul(val, 0, 16);
-		} else if (*arg != '-') {
-			/* skip over already allocated file names */
-			for (; dtb_files[dt_count]; dt_count++) {
-				if (dt_count >= DTB_MAX) {
-					fail("reached dtb file limit (%d)", DTB_MAX);
-				}
-			}
-			dtb_files[dt_count] = strdup(arg);
-			if (!dtb_files[dt_count]) {
-				fail("failed to allocate memory");
-			}
+		} else if (arg[0] != '-') {
+			add_dtb_file(&dtb_files, &dt_count, arg);
 		} else
 			usage();
 	}
@@ -405,7 +418,7 @@ int main(int argc, char **argv)
 		usage();
 	}
 
-	if (!dtb_files[0])
+	if (dt_count == 0)
 		fail("no dtb files found");
 
 	dt_data = load_dtbh_block(dtb_files, pagesize, dt_platform_code, dt_subtype_code, &dt_size);


### PR DESCRIPTION
Before these changes we allocated memory for 100 dtbs, and then checked whether a slot was already allocated with `if (dtb_files[i]) ...`. Since memory was not zeroed this check might or might not succeed, and I ran into weird errors during dtbtool-exynos usage.

Change so that all allocated memory is free'd while we are at it, and cleanup some indentation in the file. 

After these changes we can run dtbtool-exynos under valgrind without warnings about memory leaks. 